### PR TITLE
add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
-# NFT Gallery Reference
+# NFT Gallery Reference (DEPRECATED)
+
+The NFT implementation in this repository has been deprecated as it does not follow current [NEP-171 standards](https://nomicon.io/Standards/NonFungibleToken/Core.html).
+
+**For the most up-to-date example of NEAR NFT Standard Implementation please visit:** 
+
+[ https://github.com/near-examples/nft ]
+
+
+---
 
 A PoC backbone for NFT Gallery on NEAR Protocol.
 


### PR DESCRIPTION
This repository is deprecated and should point to near-examples/nft for the most up-to-date example of NFT standard implementation.